### PR TITLE
`Markdown`ified README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pulledpork
 
 Pulled Pork for Snort rule management (from Google code)
 
-Find us on Freenode (IRC) #pulledpork
+Find us on Freenode (IRC) [`#pulledpork`](https://webchat.freenode.net/?channels=pulledpork)
 
 Copyright (C) 2009-2015 JJ Cummings and the PulledPork Team!
 
@@ -13,7 +13,7 @@ guidance on the usage of PulledPork.  Please be sure to read this file
 thoroughly so that you don't overlook something!
 
 
--= Features and Capabilities =-
+## Features and Capabilities
 
  * Automated downloading, parsing, state modification and rule modification
    for all of your snort rulesets.
@@ -30,136 +30,136 @@ thoroughly so that you don't overlook something!
  * Verbose output so that you know EXACTLY what is happening
  * Minimal Perl Module dependencies
  * A sweet smokey flavor throughout the pork!
- 
 
--= Command Usage Reference =-
 
-Usage: ./pulledpork.pl [-dEgHklnRTPVvv? -help] -c <config filename> -o <rule output path>
-   -O <oinkcode> -s <so_rule output directory> -D <Distro> -S <SnortVer>
-   -p <path to your snort binary> -C <path to your snort.conf> -t <sostub output path>
-   -h <changelog path> -I (security|connectivity|balanced) -i <path to disablesid.conf>
-   -b <path to dropsid.conf> -e <path to enablesid.conf> -M <path to modifysid.conf>
-   -r <path to docs folder> -K <directory for separate rules files>
-  
-   Options:
-   
-   -help/? Print this help info.
-   
-   -b Where the dropsid config file lives.
-   
-   -C Path to your snort.conf
-   
-   -c Where the pulledpork config file lives.
-   
-   -d Do not verify signature of rules tarball, i.e. downloading fron non VRT or ET locations.
-   
-   -D What Distro are you running on, for the so_rules
-      Valid Distro Types:
-      
-		Debian-5-0, Debian-6-0, Ubuntu-8.04, Ubuntu-10-4
-		Centos-4-8, Centos-5-4,	FC-12, FC-14, RHEL-5-5, RHEL-6-0
-		FreeBSD-7-3, FreeBSD-8-1
-		OpenBSD-4-8
-		Slackware-13-1
-   
-   -e Where the enablesid config file lives.
-   
-   -E Write ONLY the enabled rules to the output files.
-   
-   -g grabonly (download tarball rule file(s) and do NOT process)
-   
-   -h path to the sid_changelog if you want to keep one?
-   
-   -H Send a SIGHUP to the pids listed in the config file
-   
-   -I Specify a base ruleset( -I security,connectivity,or balanced, see README.RULESET)
-   
-   -i Where the disablesid config file lives.
-   
-   -k Keep the rules in separate files (using same file names as found when reading)
-   
-   -K Where (what directory) do you want me to put the separate rules files?
-   
-   -l Log Important Info to Syslog (Errors, Successful run etc, all items logged as WARN or higher) 
-   
-   -L Where do you want me to read your local.rules for inclusion in sid-msg.map
-   
-   -m where do you want me to put the sid-msg.map file?
-   
-   -M where the modifysid config file lives.
-   
-   -n Do everything other than download of new files (disablesid, etc)
-   
-   -o Where do you want me to put generic rules file?
-   
-   -p Path to your Snort binary
-   
-   -P Process rules even if no new rules were downloaded
-   
-   -R When processing enablesid, return the rules to their ORIGINAL state
-   
-   -r Where do you want me to put the reference docs (xxxx.txt)
-   
-   -S What version of snort are you using
-   
-   -s Where do you want me to put the so_rules?
-   
-   -T Process text based rules files only, i.e. DO NOT process so_rules
-   
-   -u Where do you want me to pull the rules tarball from
-   ** E.g., ET, Snort.org. See pulledpork config rule_url option for value ideas
-   
-   -V Print Version and exit
+## Command Usage Reference
 
-   -v Verbose mode, you know.. for troubleshooting and such nonsense.
+    Usage: ./pulledpork.pl [-dEgHklnRTPVvv? -help] -c <config filename> -o <rule output path>
+       -O <oinkcode> -s <so_rule output directory> -D <Distro> -S <SnortVer>
+       -p <path to your snort binary> -C <path to your snort.conf> -t <sostub output path>
+       -h <changelog path> -I (security|connectivity|balanced) -i <path to disablesid.conf>
+       -b <path to dropsid.conf> -e <path to enablesid.conf> -M <path to modifysid.conf>
+       -r <path to docs folder> -K <directory for separate rules files>
 
-   -vv EXTRA Verbose mode, you know.. for in-depth troubleshooting and other such nonsense.
+    Options:
 
--=Basic Usage Examples=-
+    -help/? Print this help info.
+
+    -b Where the dropsid config file lives.
+
+    -C Path to your snort.conf
+
+    -c Where the pulledpork config file lives.
+
+    -d Do not verify signature of rules tarball, i.e. downloading fron non VRT or ET locations.
+
+    -D What Distro are you running on, for the so_rules
+       Valid Distro Types:
+
+         Debian-5-0, Debian-6-0, Ubuntu-8.04, Ubuntu-10-4
+         Centos-4-8, Centos-5-4, FC-12, FC-14, RHEL-5-5, RHEL-6-0
+         FreeBSD-7-3, FreeBSD-8-1
+         OpenBSD-4-8
+         Slackware-13-1
+
+    -e Where the enablesid config file lives.
+
+    -E Write ONLY the enabled rules to the output files.
+
+    -g grabonly (download tarball rule file(s) and do NOT process)
+
+    -h path to the sid_changelog if you want to keep one?
+
+    -H Send a SIGHUP to the pids listed in the config file
+
+    -I Specify a base ruleset( -I security,connectivity,or balanced, see README.RULESET)
+
+    -i Where the disablesid config file lives.
+
+    -k Keep the rules in separate files (using same file names as found when reading)
+
+    -K Where (what directory) do you want me to put the separate rules files?
+
+    -l Log Important Info to Syslog (Errors, Successful run etc, all items logged as WARN or higher) 
+
+    -L Where do you want me to read your local.rules for inclusion in sid-msg.map
+
+    -m where do you want me to put the sid-msg.map file?
+
+    -M where the modifysid config file lives.
+
+    -n Do everything other than download of new files (disablesid, etc)
+
+    -o Where do you want me to put generic rules file?
+
+    -p Path to your Snort binary
+
+    -P Process rules even if no new rules were downloaded
+
+    -R When processing enablesid, return the rules to their ORIGINAL state
+
+    -r Where do you want me to put the reference docs (xxxx.txt)
+
+    -S What version of snort are you using
+
+    -s Where do you want me to put the so_rules?
+
+    -T Process text based rules files only, i.e. DO NOT process so_rules
+
+    -u Where do you want me to pull the rules tarball from
+    ** E.g., ET, Snort.org. See pulledpork config rule_url option for value ideas
+
+    -V Print Version and exit
+
+    -v Verbose mode, you know.. for troubleshooting and such nonsense.
+
+    -vv EXTRA Verbose mode, you know.. for in-depth troubleshooting and other such nonsense.
+
+## Basic Usage Examples
 
 A simple example of how to use PulledPork would be to specify all of your configuration directives inside of the
-PulledPork.conf file.  Specifically for minimal function, i.e. NO Shared Object rule processing you must define 
-at a minimum the rule_file, oinkcode, temp_path, tar_path, and rule_path values.  Below are some examples of this. 
+`PulledPork.conf` file.  Specifically for minimal function, i.e. NO Shared Object rule processing you must define 
+at a minimum the `rule_file`, `oinkcode`, `temp_path`, `tar_path`, and `rule_path` values.  Below are some examples of this.
 
-./pulledpork.pl -o /usr/local/etc/snort/rules/ -O 12345667778523452344234234  \
--u http://www.snort.org/reg-rules/snortrules-snapshot-2973.tar.gz -i disablesid.conf -T -H
+    ./pulledpork.pl -o /usr/local/etc/snort/rules/ -O 12345667778523452344234234  \
+      -u http://www.snort.org/reg-rules/snortrules-snapshot-2973.tar.gz -i disablesid.conf -T -H
 
-The above will fetch the snortrules-snapshot-2973.tar.gz tarball from snort.org using the specified oinkcode of 
-12345667778523452344234234 and put the rules files from that tarball into the output path of 
-/usr/local/etc/snort/rules/ while the -i option tells pulledpork where the
-disablesid.conf lives, and the -T option tells pulledpork to not process for any shared object rules and the final
--H option tells pulledpork to send a Hangup signal to the snort pid that you defined in the pulledpork.conf.
+The above will fetch the `snortrules-snapshot-2973.tar.gz` tarball from snort.org using the specified `oinkcode` of 
+`12345667778523452344234234` and put the rules files from that tarball into the output path of 
+`/usr/local/etc/snort/rules/` while the `-i` option tells pulledpork where the
+`disablesid.conf` lives, and the `-T` option tells pulledpork to not process for any shared object rules and the final
+`-H` option tells pulledpork to send a `Hangup` signal to the snort pid that you defined in the `pulledpork.conf`.
 
-./pulledpork.pl -c pulledpork.conf -i disablesid.conf -T -H
+    ./pulledpork.pl -c pulledpork.conf -i disablesid.conf -T -H
 
-Similar to the first example but all options specified in the pulledpork.conf file (other than disablesid and -H)...
+Similar to the first example but all options specified in the `pulledpork.conf` file (other than `disablesid` and `-H`)...
 
-./pulledpork.pl -c pulledpork.conf -i disablesid.conf -m /usr/local/etc/snort/sid-msg.map -Hn
+    ./pulledpork.pl -c pulledpork.conf -i disablesid.conf -m /usr/local/etc/snort/sid-msg.map -Hn
 
-The above will simply read the disablesid and disable as defined, then send a Hangup signal after generating the sid-msg.map
+The above will simply read the disablesid and disable as defined, then send a `Hangup` signal after generating the `sid-msg.map`
 at the specified location without downloading anything.
 Highly useful when tuning / making changes etc..
 
-Next example, snort inline with rules that we want to drop and disable, then HUP our daemons after creating a sid-msg.map
-and writing change info to sid_changes.log!
+Next example, snort inline with rules that we want to drop and disable, then `HUP` our daemons after creating a `sid-msg.map`
+and writing change info to `sid_changes.log`!
 
-./pulledpork.pl -c pulledpork.conf -i disablesid.conf -b dropsid.conf -m /usr/local/etc/snort/sid-msg.map \
--h /var/log/sid_changes.log -H
+    ./pulledpork.pl -c pulledpork.conf -i disablesid.conf -b dropsid.conf -m /usr/local/etc/snort/sid-msg.map \
+      -h /var/log/sid_changes.log -H
 
 Next example, same as the previous but specifying that we want to run the default "security" based ruleset
-and that we want to enable rules specified in enablesid.conf.
+and that we want to enable rules specified in `enablesid.conf`.
 
-./pulledpork.pl -c pulledpork.conf -i disablesid.conf -b dropsid.conf -e enablesid.conf -m /usr/local/etc/snort/sid-msg.map \
--h /var/log/sid_changes.log -I security -H
+    ./pulledpork.pl -c pulledpork.conf -i disablesid.conf -b dropsid.conf -e enablesid.conf -m /usr/local/etc/snort/sid-msg.map \
+      -h /var/log/sid_changes.log -I security -H
 
-Next example, same as the previous but specifying that we want to -K (Keep) the originationg tarball names.
-and write them to /usr/local/etc/snort/rules/
+Next example, same as the previous but specifying that we want to `-K` (Keep) the originationg tarball names.
+and write them to `/usr/local/etc/snort/rules/`
 
-./pulledpork.pl -c pulledpork.conf -i disablesid.conf -b dropsid.conf -e enablesid.conf -m /usr/local/etc/snort/sid-msg.map \
--h /var/log/sid_changes.log -I security -H -K /usr/local/etc/snort/rules/
+    ./pulledpork.pl -c pulledpork.conf -i disablesid.conf -b dropsid.conf -e enablesid.conf -m /usr/local/etc/snort/sid-msg.map \
+      -h /var/log/sid_changes.log -I security -H -K /usr/local/etc/snort/rules/
 
 
-** Special Notes Section**
+##Special Notes Section
 
 Please note that pulledpork runs rule modification (enable, drop, disable, modify) in that order by default..
 
@@ -169,12 +169,12 @@ Please note that pulledpork runs rule modification (enable, drop, disable, modif
 
 3: disable
 
-This means that disable rules will always take precedence.. thusly if you specify the same gid:sid 
+This means that disable rules will always take precedence.. thusly if you specify the same `gid:sid` 
 in enable and disable configuration files, then that sid will be disabled.. keep this in mind 
 for ranges also!  However, you can specify a different order using the state_order keyword in the
 master config file.
 
-I'll probably add more info later, the --help or --? will display all runtime options and the pulledpork.conf is
+I'll probably add more info later, the `--help` or `--?` will display all runtime options and the `pulledpork.conf` is
 pretty well annotated... so if you can't figure it out... try harder!  And once you figure it out, please feel 
 free to contribute with additional readme / help foo.. thx!
 


### PR DESCRIPTION
A bunch of code examples where not treated as code and thus copy/pasting them wouldn't work without modifications.
Took the opportunity to add some markdown structure to the document.