### PR TITLE
Link to free ET Rules fixed

### DIFF
--- a/etc/pulledpork.conf
+++ b/etc/pulledpork.conf
@@ -24,7 +24,7 @@ rule_url=https://s3.amazonaws.com/snort-org/www/rules/community/|community-rules
 rule_url=http://talosintel.com/files/additional_resources/ips_blacklist/ip-filter.blf|IPBLACKLIST|open
 # URL for rule documentation! (slow to process)
 rule_url=https://www.snort.org/reg-rules/|opensource.gz|<oinkcode>
-#rule_url=https://rules.emergingthreatspro.com/|emerging.rules.tar.gz|open
+#rule_url=https://rules.emergingthreats.net/|emerging.rules.tar.gz|open-nogpl
 # THE FOLLOWING URL is for etpro downloads, note the tarball name change!
 # and the et oinkcode requirement!
 #rule_url=https://rules.emergingthreatspro.com/|etpro.rules.tar.gz|<et oinkcode>
@@ -124,7 +124,7 @@ config_path=/usr/local/etc/snort/snort.conf
 # Debian-6-0, Ubuntu-10-4
 # Ubuntu-12-04, Centos-5-4
 # FC-12, FC-14, RHEL-5-5, RHEL-6-0
-# FreeBSD-8-1, FreeBSD-9-0, FreeBSD-10-0
+# FreeBSD-8-1, FreeBSD-10-0
 # OpenBSD-5-2, OpenBSD-5-3
 # OpenSUSE-11-4, OpenSUSE-12-1
 # Slackware-13-1
@@ -206,4 +206,4 @@ snort_control=/usr/local/bin/snort_control
 ####### need to process so_rules, simply comment out the so_rule section
 ####### you can also specify -T at runtime to process only GID 1 rules.
 
-version=0.7.2
+version=0.7.1


### PR DESCRIPTION
The ET pro link does not work for the free rules, needs to be:
https://rules.emergingthreats.net/|emerging.rules.tar.gz|open-nogpl

Options:
open (includes Snort's basic rules - good for using a single ET rules link)
or
open-nogpl (does not include Snort's basic rules - avoids conflicts)