### PR TITLE
ET rule URL cannot handle https

### DIFF
--- a/etc/pulledpork.conf
+++ b/etc/pulledpork.conf
@@ -26,7 +26,7 @@ rule_url=http://talosintel.com/files/additional_resources/ips_blacklist/ip-filte
 rule_url=https://www.snort.org/reg-rules/|opensource.gz|<oinkcode>
 # THE FOLLOWING URL is for emergingthreats downloads, note the tarball name change!
 # and open-nogpl, to avoid conflicts.
-#rule_url=https://rules.emergingthreats.net/|emerging.rules.tar.gz|open-nogpl
+#rule_url=http://rules.emergingthreats.net/|emerging.rules.tar.gz|open-nogpl
 # THE FOLLOWING URL is for etpro downloads, note the tarball name change!
 # and the et oinkcode requirement!
 #rule_url=https://rules.emergingthreatspro.com/|etpro.rules.tar.gz|<et oinkcode>


### PR DESCRIPTION
Checking latest MD5 for emerging.rules.tar.gz....
        Error 500 when fetching https://rules.emergingthreats.net/open-nogpl/snort-2.9.7/emerging.rules.tar.gz.md5 at /usr/local/bin/pulledpork.pl line 482.
        main::md5file("open-nogpl", "emerging.rules.tar.gz", "/var/tmp/", "https://rules.emergingthreats.net/open-nogpl/snort-2.9.7/") called at /usr/local/bin/pulledpork.pl line 1901

Once I changed https to normal http, it works:
rule_url=http://rules.emergingthreats.net/|emerging.rules.tar.gz|open-nogpl

Might need to change the Pro to http also:
rule_url=http://rules.emergingthreatspro.com/|etpro.rules.tar.gz|<et oinkcode>