### PR TITLE
No ignores give: unnitialized value in pulledpork.pl error

### DIFF
--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -228,7 +228,7 @@ sub rule_extract {
     $tar->read( $temp_path . $rule_file );
     $tar->setcwd( cwd() );
     local $Archive::Tar::CHOWN = 0; 
-    my @ignores = split( /,/, $ignore );
+    my @ignores = split( /,/, $ignore ) if (defined $ignore);
 
     foreach (@ignores) {
         if ( $_ =~ /\.rules/ ) {


### PR DESCRIPTION
If you have nothing to ignore in your pulledpork.conf, then there are issues:
Use of uninitialized value in concatenation (.) or string at /usr/local/bin/pulledpork.pl line 1593.
        ignore = 
Prepping rules from emerging.rules.tar.gz for work....
Use of uninitialized value in split at /usr/local/bin/pulledpork.pl line 231.
Prepping rules from community-rules.tar.gz for work....
Use of uninitialized value in split at /usr/local/bin/pulledpork.pl line 231.
Prepping rules from snortrules-snapshot-2973.tar.gz for work....
Use of uninitialized value in split at /usr/local/bin/pulledpork.pl line 231.