### PR TITLE
FIXED: uninitialized value in concatenation

### DIFF
--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -1590,7 +1590,7 @@ if ( exists $Config_info{'ignore_file'})
 {
   $ignore_files = get_ignore_files($Config_info{'ignore_file'});
 }
-print "\tignore = $ignore_files\n";
+print "\tignore = $ignore_files\n" if (defined my $ignore);
 
 if ($rule_file_path) {
     $keep_rulefiles = 1;


### PR DESCRIPTION
If you have nothing to ignore in your pulledpork.conf, then there are issues:
Use of uninitialized value in concatenation (.) or string at /usr/local/bin/pulledpork.pl line 1593.
ignore =