### PR TITLE
Use of uninitialized value in split

### DIFF
--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -251,7 +251,7 @@ sub rule_extract {
     $tar->read( $temp_path . $rule_file );
     $tar->setcwd( cwd() );
     local $Archive::Tar::CHOWN = 0; 
-    my @ignores = split( /,/, $ignore );
+    my @ignores = split( /,/, $ignore ) if (defined $ignore);
 
     foreach (@ignores) {
         if ( $_ =~ /\.rules/ ) {


### PR DESCRIPTION
Prepping rules from emerging.rules.tar.gz for work....
Use of uninitialized value in split at /usr/local/bin/pulledpork.pl line 254.
        Done!
Prepping rules from community-rules.tar.gz for work....
Use of uninitialized value in split at /usr/local/bin/pulledpork.pl line 254.
        Done!
Prepping rules from snortrules-snapshot-2973.tar.gz for work....
Use of uninitialized value in split at /usr/local/bin/pulledpork.pl line 254.