### PR TITLE
syslogit: Move $Syslogging check into syslogit() function

### DIFF
--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -56,8 +56,7 @@ if ($oSystem =~ /freebsd/i) {
            $ua->ssl_opts( SSL_ca_file => $CAFile );
         } else {	
     	   carp "ERROR: $CAFile is not readable by ".(getpwuid($<))[0]."\n";
-	   syslogit( 'err|local0', "FATAL: ERROR: $CAFile is not readable by ".(getpwuid($<))[0]."\n")
-	   if $Syslogging;
+	   syslogit( 'err|local0', "FATAL: ERROR: $CAFile is not readable by ".(getpwuid($<))[0]."\n");
  	   exit(1);
         }
     #Check for the other location for the cert file
@@ -67,14 +66,12 @@ if ($oSystem =~ /freebsd/i) {
            $ua->ssl_opts( SSL_ca_file => $CAFile );
         } else {	
     	   carp "ERROR: $CAFile is not readable by ".(getpwuid($<))[0]."\n";
-	   syslogit( 'err|local0', "FATAL: ERROR: $CAFile is not readable by ".(getpwuid($<))[0]."\n")
-	   if $Syslogging;
+	   syslogit( 'err|local0', "FATAL: ERROR: $CAFile is not readable by ".(getpwuid($<))[0]."\n");
  	   exit(1);
         }
     } else {
            carp "ERROR: cert file does not exist (/etc/ssl/cert.pem or /usr/local/etc/ssl/cert.pem) Ensure that the ca_root_nss port/pkg is installed, or use -w to skip SSL verification\n";
-           syslogit( 'err|local0', "FATAL: cert file does not exist. Ensure that the ca_root_nss port/pkg is installed, or use -w to skip SSL verification\n")
-           if $Syslogging;
+           syslogit( 'err|local0', "FATAL: cert file does not exist. Ensure that the ca_root_nss port/pkg is installed, or use -w to skip SSL verification\n");
            exit(1);
     }
 }
@@ -129,8 +126,7 @@ sub parse_config_file {
 
     if ( !open( CONFIG, "$FileConf" ) ) {
         carp "ERROR: Config file not found : $FileConf\n";
-        syslogit( 'err|local0', "FATAL: Config file not found: $FileConf" )
-          if $Syslogging;
+        syslogit( 'err|local0', "FATAL: Config file not found: $FileConf" );
         exit(1);
     }
     open( CONFIG, "$FileConf" );
@@ -395,8 +391,7 @@ sub getstore {
     	   $response->code;
         } else {	
     	   carp "ERROR: $file is not writable by ".(getpwuid($<))[0]."\n";
-	   syslogit( 'err|local0', "FATAL: $file is not writable by ".(getpwuid($<))[0]."\n" )
-	   if $Syslogging;
+	   syslogit( 'err|local0', "FATAL: $file is not writable by ".(getpwuid($<))[0]."\n" );
  	   exit(1);
         }
     } else {
@@ -439,25 +434,23 @@ sub rulefetch {
         print
 "\tA 403 error occurred, please wait for the 15 minute timeout\n\tto expire before trying again or specify the -n runtime switch\n",
 "\tYou may also wish to verfiy your oinkcode, tarball name, and other configuration options\n";
-        syslogit( 'emerg|local0', "FATAL: 403 error occured" ) if $Syslogging;
+        syslogit( 'emerg|local0', "FATAL: 403 error occured" );
         exit(1);    # For you shirkdog
     }
     elsif ( $getrules_rule == 404 ) {
         print
 "\tA 404 error occurred, please verify your filenames and urls for your tarball!\n";
-        syslogit( 'emerg|local0', "FATAL: 404 error occured" ) if $Syslogging;
+        syslogit( 'emerg|local0', "FATAL: 404 error occured" );
         exit(1);    # For you shirkdog
     }
     elsif ( $getrules_rule == 500 ) {
         print
 "\tA 500 error occurred, please verify that you have recently updated your root certificates!\n";
-        syslogit( 'emerg|local0', "FATAL: 500 error occured" ) if $Syslogging;
+        syslogit( 'emerg|local0', "FATAL: 500 error occured" );
         exit(1);    # Certs bitches!
     }
     unless ( is_success($getrules_rule) ) {
-        syslogit( 'emerg|local0',
-            "FATAL: Error $getrules_rule when fetching $rule_file" )
-          if $Syslogging;
+        syslogit( 'emerg|local0', "FATAL: Error $getrules_rule when fetching $rule_file" );
         croak "\tError $getrules_rule when fetching " . $rule_file;
     }
 
@@ -720,8 +713,7 @@ sub gen_stubs {
         while (<FH>) {
             print "\t$_" if $_ =~ /Dumping/i && ( $Verbose && !$Quiet );
             next unless $_ =~ /(err|warn|fail)/i;
-            syslogit( 'warning|local0', "FATAL: An error occured: $_" )
-              if $Syslogging;
+            syslogit( 'warning|local0', "FATAL: An error occured: $_" );
             print "\tAn error occurred: $_\n";
 
             # Yes, this is lame error reporting to stdout ...
@@ -1481,7 +1473,7 @@ sub get_arch {
 ## log to syslog
 sub syslogit {
     my ( $level, $msg ) = @_;
-
+    return if !$Syslogging;
     openlog( 'pulledpork', 'ndelay,pid', 'local0' );
     syslog( $level, $msg );
     closelog;
@@ -2136,6 +2128,6 @@ if ( $sid_changelog && -f $Output ) {
 }
 
 print("Fly Piggy Fly!\n") if !$Quiet;
-syslogit( 'warning|local0', "INFO: Finished Cleanly" ) if $Syslogging;
+syslogit( 'warning|local0', "INFO: Finished Cleanly" );
 
 __END__


### PR DESCRIPTION
This change cleans up calling code removing need to check $Syslogging value,
instead moving the check into the syslogit() function where it will return if
not evaulating True.