### PR TITLE
Fix duplicate rules

### DIFF
--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -655,7 +655,9 @@ sub read_rules {
 			$$hashref{ trim($gid) }{ trim($sid) }{'rule'} = $rule;
                         $$hashref{ trim($gid) }{ trim($sid) }{'category'} =
                           $file;
-			push @ {$categories->{$file}{trim($gid)}},($sid);
+			push @ {$categories->{$file}{trim($gid)}},($sid)
+			    if !exists $categories->{$file}{trim($gid)}[$sid];
+
                     }
                 }
             }


### PR DESCRIPTION
Every time read_rules is called, it was creating a duplicate entry in the categories array