### PR TITLE
Fix: use of uninitialized value because of autovivification

### DIFF
--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -832,7 +832,7 @@ sub modify_sid {
                 if (not defined $gid) {
                     $gid = 1;
                 }
-                if ( $sid ne "*" && defined $$href{$gid}{$sid}{'rule'} ) {
+                if ( $sid ne "*" && safe_defined($href, $gid, $sid, 'rule')) {
                     print "\tModifying GID:$gid,SID:$sid from:$from to:$to\n"
                       if ( $Verbose && !$Quiet );
                     $$href{$gid}{$sid}{'rule'} =~ s/$from/$to/;
@@ -1468,6 +1468,17 @@ sub slash {
         $string = $string . "/";
     }
     return $string;
+}
+
+## Test the intermediate levels with exists to prevent unintended autovivification
+sub safe_defined {
+    my ($h, @keys) = @_;
+    foreach my $k (@keys) {
+        return unless ref $h eq 'HASH';
+        return unless exists $h->{$k};
+        $h = $h->{$k};
+    }
+    return defined $h;
 }
 
 ## uh, yeah


### PR DESCRIPTION
Unintended situation happen in the following case: 

```
$ cat etc/modify.conf
33881 "\$HOME_NET" "$MY_HOME_NET"
```

However, sid:33881 was disabled.
```
$ grep 33881 snortrules-snapshot-2983/rules/deleted.rules
# alert udp $HOME_NET any -> any 53 (msg:"DELETED BLACKLIST DNS request for known malware domain did.ijinshan.com - Win.Trojan.Jadtre"; flow:to_server; byte_test:1,!&,0xF8,2; content:"|03|did|08|ijinshan|03|com|00|"; fast_pattern:only; reference:url,www.virustotal.com/en/file/7afc3aa4453603d6b11315c3a6a1d80fd36b42fc03f17116c92bc465680b0089/analysis/; classtype:trojan-activity; sid:33881; rev:2;)
```

In this case, I got the following warning.
```
$ ./pulledpork.pl -c etc/pulledpork.conf
...
Use of uninitialized value $msg_holder in pattern match (m//) at ./pulledpork.pl line 1353.
Use of uninitialized value $msg_holder in pattern match (m//) at ./pulledpork.pl line 1382.
...
```

This is caused by autovivification  in `define` function.
https://github.com/shirkdog/pulledpork/blob/master/pulledpork.pl#L835

The simple cases for autovivification
```
use Data::Dumper;

my $data;

if(defined $$data{foo}{bar}{baz}){
    print "hello\n";
}

print Dumper $data;

#$VAR1 = {
#          'foo' => {
#                     'bar' => {}
#                   }
#        };
```
`rule` key is not defined, but `$gid` key is created.
So, `$$new_hash{$k1}{$k2}{'rule'}` returns undef.
https://github.com/shirkdog/pulledpork/blob/master/pulledpork.pl#L1349
https://github.com/shirkdog/pulledpork/blob/master/pulledpork.pl#L1352

It should be tested the intermediate levels to prevent unintended autovivification.
I added `safe_defined`.

Thank you!