### PR TITLE
documentation for opensource rules is available without oinkcode

### DIFF
--- a/etc/pulledpork.conf
+++ b/etc/pulledpork.conf
@@ -23,7 +23,7 @@ rule_url=https://snort.org/downloads/community/|community-rules.tar.gz|Community
 # This format MUST be followed to let pulledpork know that this is a blacklist
 rule_url=http://talosintelligence.com/feeds/ip-filter.blf|IPBLACKLIST|open
 # URL for rule documentation! (slow to process)
-rule_url=https://www.snort.org/reg-rules/|opensource.gz|<oinkcode>
+rule_url=https://snort.org/downloads/community/|opensource.tar.gz|Opensource
 # THE FOLLOWING URL is for emergingthreats downloads, note the tarball name change!
 # and open-nogpl, to avoid conflicts.
 #rule_url=https://rules.emergingthreats.net/|emerging.rules.tar.gz|open-nogpl


### PR DESCRIPTION
I believe the documentation for opensource rules is available for download without oinkcode