### PR TITLE
Issue 144 - Use of uninitialized value $Snort_path in -B at pulledpork line 1630.

### DIFF
--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -1770,7 +1770,7 @@ if ( !$Snort ) {
 
 if ( !$Snort_path ) {
     $Snort_path = ( $Config_info{'snort_path'} );
-    $Snort      = snort_version($Snort_path) if ( -B $Snort_path && !$Snort );
+    $Snort      = snort_version($Snort_path) if ( !$Snort && -B $Snort_path );
     $arch       = get_arch();
     $Textonly   = 1 unless $Snort;
 }


### PR DESCRIPTION
Line indicated in the title has since changed, but kept title for posterity.