### PR TITLE
Added the ability to modify rules based on regex instead of hardcoded SID

### DIFF
--- a/etc/modifysid.conf
+++ b/etc/modifysid.conf
@@ -2,6 +2,9 @@
 #
 # Change history:
 # -----------------------------------------------
+# v1.2 2/28/2018 Scott Savarese
+# - Insert comments around using regex to match rules
+#
 # v1.1 2/18/2011  Alan Ptak
 # - Inserted comments around example elements that would otherwise modify rules
 #
@@ -38,3 +41,10 @@
 # that it is a SNORTSAM block rule!
 # 17803 "\(msg:"" "\(msg:"SNORTSAM ";
 # 17803 "^\s*alert" "BLOCK";
+
+# A new regex formatting syntax is available:
+# regex:'PUT_REGEX_HERE' "what I'm replacing" "what I'm replacing it with"
+# This would allow users to manipulate groups of rules. This works the same
+# way as the signature based rules, but instead of matching a hardcoded set of
+# SID, it will go through all rules in GID:1 matching the regex against the
+# rule. Be sure to escape things like ( and '

--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -943,7 +943,21 @@ sub modify_sid {
             }
             undef @arry;
         }
+
+        # Handle use case where we want to mofidy multiple sids based on
+        # comment in rule (think multiple rules with same or similar comment)
+        if ( $_ =~ /^regex:'([^']+)'\s+"(.+)"\s+"(.*)"/ ) {
+            my ( $regex, $from, $to ) = ( $1, $2, $3 );
+            # Go through each rule in gid:1 and look for matching rules
+            foreach my $sid ( sort keys( %{ $$href{1} } ) ) {
+                next unless ( $$href{1}{$sid}{'rule'} =~ /$regex/ );
+                print "\tModifying SID:$sid from:$from to:$to\n"
+                  if ( $Verbose && !$Quiet );
+                $$href{1}{$sid}{'rule'} =~ s/$from/$to/;
+            }
+        }
     }
+
     print "\tDone!\n" if !$Quiet;
     close(FH);
 }

--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -1491,9 +1491,9 @@ sub changelog {
             next if (($enonly) && ($$new_hash{$k1}{$k2}{'rule'} =~ /^\s*#/));
             if (!defined $$old_hash{$k1}{$k2}{'rule'}) {
                 my $msg_holder = $$new_hash{$k1}{$k2}{'rule'};
-                if ($msg_holder =~ /msg:\s+"[^"]+";/i) {
+                if ($msg_holder =~ /msg:"[^"]+";/i) {
                     $msg_holder = $&;
-                    $msg_holder =~ s/msg:\s+"//;
+                    $msg_holder =~ s/msg:"//;
                     $msg_holder =~ s/";//;
                 }
                 else { $msg_holder = "Unknown MSG" }
@@ -1520,9 +1520,9 @@ sub changelog {
             next
                 if (($enonly) && ($$old_hash{$k1}{$k2}{'rule'} =~ /^\s*#/));
             my $msg_holder = $$old_hash{$k1}{$k2}{'rule'};
-            if ($msg_holder =~ /msg:\s+"[^"]+";/) {
+            if ($msg_holder =~ /msg:"[^"]+";/) {
                 $msg_holder = $&;
-                $msg_holder =~ s/msg:\s+"//;
+                $msg_holder =~ s/msg:"//;
                 $msg_holder =~ s/";//;
             }
             else { $msg_holder = "Unknown MSG" }

--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -1491,9 +1491,9 @@ sub changelog {
             next if (($enonly) && ($$new_hash{$k1}{$k2}{'rule'} =~ /^\s*#/));
             if (!defined $$old_hash{$k1}{$k2}{'rule'}) {
                 my $msg_holder = $$new_hash{$k1}{$k2}{'rule'};
-                if ($msg_holder =~ /msg:"[^"]+";/i) {
+                if ($msg_holder =~ /msg:\s+"[^"]+";/i) {
                     $msg_holder = $&;
-                    $msg_holder =~ s/msg:"//;
+                    $msg_holder =~ s/msg:\s+"//;
                     $msg_holder =~ s/";//;
                 }
                 else { $msg_holder = "Unknown MSG" }
@@ -1520,9 +1520,9 @@ sub changelog {
             next
                 if (($enonly) && ($$old_hash{$k1}{$k2}{'rule'} =~ /^\s*#/));
             my $msg_holder = $$old_hash{$k1}{$k2}{'rule'};
-            if ($msg_holder =~ /msg:"[^"]+";/) {
+            if ($msg_holder =~ /msg:\s+"[^"]+";/) {
                 $msg_holder = $&;
-                $msg_holder =~ s/msg:"//;
+                $msg_holder =~ s/msg:\s+"//;
                 $msg_holder =~ s/";//;
             }
             else { $msg_holder = "Unknown MSG" }


### PR DESCRIPTION
My client has a use case where our rules vendor maintains groups of rules that are the same except for the IP addresses being matched. In our use case to use the existing modify function around sids, we'd have to add 600+ SID to the modifysid.conf file. Plus if the vendor ever added more rules in that group, we'd have to add those SID manually. This was undesirable. By using the regex, it becomes much more automatic and thus scalable for our needs.