### PR TITLE
Solve #313: Join `IPRVersion` path with slash

### DIFF
--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -1292,7 +1292,7 @@ sub rule_category_write {
 ## write our blacklist and blacklist version file!
 sub blacklist_write {
     my ($href, $path) = @_;
-    my $blv   = $Config_info{'IPRVersion'} . "IPRVersion.dat";
+    my $blv   = $Config_info{'IPRVersion'} . "/IPRVersion.dat";
     my $blver = 0;
 
     # First lets be sure that our data is new, if not skip the rest of it!


### PR DESCRIPTION
The `IPRVersion` variable is already checked to ensure it
contains a valid directory. This change just ensures that
the blacklist version is written to
`.../iplists/IPRVersion.dat` rather than
`.../iplistsIPRVersion.dat`.

The added slash should cause no trouble if the `IPRVersion`
variable contains a trailing slash, as repeated slashes are
idempotent.