### PR TITLE
add ET prefix to emergingthreatspro.com ruleset

### DIFF
--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -2133,6 +2133,7 @@ if (@base_url && -d $temp_path) {
                 }
             }
             elsif ($base_url =~ /emergingthreatspro.com/) {
+                $prefix = "ET-";
 
                 # These have to be handled separately, as emerginthreatspro will
                 # support a full version, but emergingthreats only supports the


### PR DESCRIPTION
When using a rule_url like this: 
`rule_url=https://rules.emergingthreatspro.com/|etpro.rules.tar.gz|<oinkcode>`
All the files end up with the prefix "Custom-" because no prefix definition has been made.
This PR solves this problem adding the prefix on the emergingthreatspro if clause.