### PR TITLE
Use 'eq' operator instead of '==' for strings comparison. Should fix …

### DIFF
--- a/pulledpork.pl
+++ b/pulledpork.pl
@@ -2395,7 +2395,7 @@ if (   ($Output || ($keep_rulefiles && $rule_file_path))
 
         # This may need to be changed, but for now, error out
         # if the signal name is not SIGHUP or SIGUSR2
-        if ($SigName == "SIGHUP" || $SigName == "SIGUSR2") {
+        if ($SigName eq "SIGHUP" || $SigName eq "SIGUSR2") {
             send_signal($SigName, $pid_path) unless $Sostubs;
             print "WARNING, cannot send signal if also processing SO rules\n",
                 "\tsee README.SHAREDOBJECTS\n", "\tor use -T flag!\n"


### PR DESCRIPTION
…issue #325 