### PR TITLE
Must use wildcard for all SID, if no number used

### DIFF
--- a/etc/modifysid.conf
+++ b/etc/modifysid.conf
@@ -30,7 +30,7 @@
 
 # the following would replace HTTP_PORTS with HTTPS_PORTS for ALL GID:1
 # rules
-# "HTTP_PORTS" "HTTPS_PORTS"
+# * "HTTP_PORTS" "HTTPS_PORTS"
 
 # multiple sids can be specified as noted below:
 # 302,429,1821 "\$EXTERNAL_NET" "$HOME_NET"


### PR DESCRIPTION
The modification fails to execute because it is looking for 3 arguments.
Must use a wildcard for all SID, if no number used.