### PR TITLE
Wrap README command examples at <=80 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,60 +34,62 @@ thoroughly so that you don't overlook something!
 
 ## Command Usage Reference
 
-    Usage: pulledpork.pl [-dEgklnRTPVvv? -help] -c <config filename> -o <rule output path>
-     -O <oinkcode> -s <so_rule output directory> -D <Distro> -S <SnortVer>
-     -p <path to your snort binary> -C <path to your snort.conf> -t <sostub output path>
-     -h <changelog path> -H <signal_name> -I (security|connectivity|balanced) -i <path to disablesid.conf>
-     -b <path to dropsid.conf> -e <path to enablesid.conf> -M <path to modifysid.conf>
-     -r <path to docs folder> -K <directory for separate rules files>
+```
+Usage: pulledpork.pl [-dEgklnRTPVvv? -help] -c <config filename> -o <rule output path>
+ -O <oinkcode> -s <so_rule output directory> -D <Distro> -S <SnortVer>
+ -p <path to your snort binary> -C <path to your snort.conf> -t <sostub output path>
+ -h <changelog path> -H <signal_name> -I (security|connectivity|balanced) -i <path to disablesid.conf>
+ -b <path to dropsid.conf> -e <path to enablesid.conf> -M <path to modifysid.conf>
+ -r <path to docs folder> -K <directory for separate rules files>
 
-     Options:
-     -help/? Print this help info.
-     -b Where the dropsid config file lives.
-     -C Path to your snort.conf
-     -c Where the pulledpork config file lives.
-     -d Do not verify signature of rules tarball, i.e. downloading fron non VRT or ET locations.
-     -D What Distro are you running on, for the so_rules
-        For latest supported options see http://www.snort.org/snort-rules/shared-object-rules
-        Valid Distro Types:
-          Centos-5-4, Centos-6, Centos-7
-          Debian-7, Debian-8, Debian-9
-          FC-25, FC-26, FC-27, FC-30
-          FreeBSD-8-1, FreeBSD-9-0, FreeBSD-10-0, FreeBSD-11, FreeBSD-12
-          OpenBSD-5-2, OpenBSD-5-3, OpenBSD-6-2, OpenSUSE-15-0, OpenSUSE-42-3
-          RHEL-5-5, RHEL-6, RHEL-6-0, RHEL-7
-          Slackware-13-1, Slackware-14-2
-          Ubuntu-14-4, Ubuntu-16-4, Ubuntu-17-10, Ubuntu-18-4
-     -e Where the enablesid config file lives.
-     -E Write ONLY the enabled rules to the output files.
-     -g grabonly (download tarball rule file(s) and do NOT process)
-     -h path to the sid_changelog if you want to keep one?
-     -H Send signal_name to the pids listed in the config file (SIGHUP or SIGUSR2)
-     -I Specify a base ruleset( -I security,connectivity,or balanced, see README.RULESET)
-     -i Where the disablesid config file lives.
-     -k Keep the rules in separate files (using same file names as found when reading)
-     -K Where (what directory) do you want me to put the separate rules files?
-     -l Log Important Info to Syslog (Errors, Successful run etc, all items logged as WARN or higher)
-     -L Where do you want me to read your local.rules for inclusion in sid-msg.map
-     -m where do you want me to put the sid-msg.map file?
-     -M where the modifysid config file lives.
-     -n Do everything other than download of new files (disablesid, etc)
-     -o Where do you want me to put generic rules file?
-     -O Define the oinkcode on the command line (necessary for some users)
-     -p Path to your Snort binary
-     -P Process rules even if no new rules were downloaded
-     -R When processing enablesid, return the rules to their ORIGINAL state
-     -r Where do you want me to put the reference docs (xxxx.txt)
-     -S What version of snort are you using (2.8.6 or 2.9.0) are valid values
-     -s Where do you want me to put the so_rules?
-     -T Process text based rules files only, i.e. DO NOT process so_rules
-     -u Where do you want me to pull the rules tarball from
-        ** E.g., ET, Snort.org. See pulledpork config rule_url option for value ideas
-     -V Print Version and exit
-     -v Verbose mode, you know.. for troubleshooting and such nonsense.
-     -vv EXTRA Verbose mode, you know.. for in-depth troubleshooting and other such nonsense.
-     -w Skip the SSL verification (if there are issues pulling down rule files)
-     -W Where you want to work around the issue where some implementations of LWP do not work with pulledpork's proxy configuration.
+ Options:
+ -help/? Print this help info.
+ -b Where the dropsid config file lives.
+ -C Path to your snort.conf
+ -c Where the pulledpork config file lives.
+ -d Do not verify signature of rules tarball, i.e. downloading fron non VRT or ET locations.
+ -D What Distro are you running on, for the so_rules
+    For latest supported options see http://www.snort.org/snort-rules/shared-object-rules
+    Valid Distro Types:
+      Centos-5-4, Centos-6, Centos-7
+      Debian-7, Debian-8, Debian-9
+      FC-25, FC-26, FC-27, FC-30
+      FreeBSD-8-1, FreeBSD-9-0, FreeBSD-10-0, FreeBSD-11, FreeBSD-12
+      OpenBSD-5-2, OpenBSD-5-3, OpenBSD-6-2, OpenSUSE-15-0, OpenSUSE-42-3
+      RHEL-5-5, RHEL-6, RHEL-6-0, RHEL-7
+      Slackware-13-1, Slackware-14-2
+      Ubuntu-14-4, Ubuntu-16-4, Ubuntu-17-10, Ubuntu-18-4
+ -e Where the enablesid config file lives.
+ -E Write ONLY the enabled rules to the output files.
+ -g grabonly (download tarball rule file(s) and do NOT process)
+ -h path to the sid_changelog if you want to keep one?
+ -H Send signal_name to the pids listed in the config file (SIGHUP or SIGUSR2)
+ -I Specify a base ruleset( -I security,connectivity,or balanced, see README.RULESET)
+ -i Where the disablesid config file lives.
+ -k Keep the rules in separate files (using same file names as found when reading)
+ -K Where (what directory) do you want me to put the separate rules files?
+ -l Log Important Info to Syslog (Errors, Successful run etc, all items logged as WARN or higher)
+ -L Where do you want me to read your local.rules for inclusion in sid-msg.map
+ -m where do you want me to put the sid-msg.map file?
+ -M where the modifysid config file lives.
+ -n Do everything other than download of new files (disablesid, etc)
+ -o Where do you want me to put generic rules file?
+ -O Define the oinkcode on the command line (necessary for some users)
+ -p Path to your Snort binary
+ -P Process rules even if no new rules were downloaded
+ -R When processing enablesid, return the rules to their ORIGINAL state
+ -r Where do you want me to put the reference docs (xxxx.txt)
+ -S What version of snort are you using (2.8.6 or 2.9.0) are valid values
+ -s Where do you want me to put the so_rules?
+ -T Process text based rules files only, i.e. DO NOT process so_rules
+ -u Where do you want me to pull the rules tarball from
+    ** E.g., ET, Snort.org. See pulledpork config rule_url option for value ideas
+ -V Print Version and exit
+ -v Verbose mode, you know.. for troubleshooting and such nonsense.
+ -vv EXTRA Verbose mode, you know.. for in-depth troubleshooting and other such nonsense.
+ -w Skip the SSL verification (if there are issues pulling down rule files)
+ -W Where you want to work around the issue where some implementations of LWP do not work with pulledpork's proxy configuration.
+ ```
 
 
 ## Basic Usage Examples
@@ -97,8 +99,9 @@ A simple example of how to use PulledPork would be to specify all of your config
 at a minimum the `rule_file`, `oinkcode`, `temp_path`, `tar_path`, and `rule_path` values.  Below are some examples of this.
 
 ```bash
-./pulledpork.pl -o /usr/local/etc/snort/rules/ -O 12345667778523452344234234  \
-  -u http://www.snort.org/reg-rules/snortrules-snapshot-2973.tar.gz -i disablesid.conf -T -H
+./pulledpork.pl -o /usr/local/etc/snort/rules/ -O 12345667778523452344234234 \
+  -u http://www.snort.org/reg-rules/snortrules-snapshot-2973.tar.gz \
+  -i disablesid.conf -T -H
 ```
 
 The above will fetch the `snortrules-snapshot-2973.tar.gz` tarball from snort.org using the specified `oinkcode` of 
@@ -114,7 +117,8 @@ The above will fetch the `snortrules-snapshot-2973.tar.gz` tarball from snort.or
 Similar to the first example but all options specified in the `pulledpork.conf` file (other than `disablesid` and `-H`)...
 
 ```bash
-./pulledpork.pl -c pulledpork.conf -i disablesid.conf -m /usr/local/etc/snort/sid-msg.map -Hn
+./pulledpork.pl -c pulledpork.conf -i disablesid.conf \
+  -m /usr/local/etc/snort/sid-msg.map -Hn
 ```
 
 The above will simply read the disablesid and disable as defined, then send a `Hangup` signal after generating the `sid-msg.map`
@@ -125,15 +129,16 @@ Next example, snort inline with rules that we want to drop and disable, then `HU
 and writing change info to `sid_changes.log`!
 
 ```bash
-./pulledpork.pl -c pulledpork.conf -i disablesid.conf -b dropsid.conf -m /usr/local/etc/snort/sid-msg.map \
-  -h /var/log/sid_changes.log -H
+./pulledpork.pl -c pulledpork.conf -i disablesid.conf -b dropsid.conf \
+  -m /usr/local/etc/snort/sid-msg.map -h /var/log/sid_changes.log -H
 ```
 
 Next example, same as the previous but specifying that we want to run the default "security" based ruleset
 and that we want to enable rules specified in `enablesid.conf`.
 
 ```bash
-./pulledpork.pl -c pulledpork.conf -i disablesid.conf -b dropsid.conf -e enablesid.conf -m /usr/local/etc/snort/sid-msg.map \
+./pulledpork.pl -c pulledpork.conf -i disablesid.conf -b dropsid.conf \
+  -e enablesid.conf -m /usr/local/etc/snort/sid-msg.map \
   -h /var/log/sid_changes.log -I security -H
 ```
 
@@ -141,7 +146,8 @@ Next example, same as the previous but specifying that we want to `-K` (Keep) th
 and write them to `/usr/local/etc/snort/rules/`
 
 ```bash
-./pulledpork.pl -c pulledpork.conf -i disablesid.conf -b dropsid.conf -e enablesid.conf -m /usr/local/etc/snort/sid-msg.map \
+./pulledpork.pl -c pulledpork.conf -i disablesid.conf -b dropsid.conf \
+  -e enablesid.conf -m /usr/local/etc/snort/sid-msg.map \
   -h /var/log/sid_changes.log -I security -H -K /usr/local/etc/snort/rules/
 ```
 


### PR DESCRIPTION
Leaving the command usage long because it's less critical for readability than the command examples.